### PR TITLE
add missing space in description

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
       <div class="row banner">
          <div class="banner-text">
             <h1 class="responsive-headline">I'm Revathi Prabhala.</h1>
-            <h3>I'm a machine learning enthusiast</span>and a <span>coder</span>.<a class="smoothscroll" href="#about"> Start scrolling </a>and learn more <a class="smoothscroll" href="#about">about me</a>.</h3>
+            <h3>I'm a machine learning enthusiast </span>and a <span>coder</span>.<a class="smoothscroll" href="#about"> Start scrolling </a>and learn more <a class="smoothscroll" href="#about">about me</a>.</h3>
             <hr />
             <ul class="social">
                <li><a href="https://www.linkedin.com/in/revathi-prabhala/"><i class="fa fa-linkedin"></i></a></li>


### PR DESCRIPTION
I was looking at https://reprabhala.github.io/ and noticed there should be a space between "enthusiast" and "and". I think this PR will fix it 😀 

![image](https://user-images.githubusercontent.com/7608904/106238380-6c1a1680-61c6-11eb-99bb-2314c7b314c5.png)
